### PR TITLE
Fix Makefile.pl to work in strict sub mode

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,13 +15,10 @@ test_requires 'Test::Deep';
 test_requires 'Test::Base';
 test_requires 'Test::TCP' => '0.08';
 
-use_test_base;
-
 tests('t/*.t');
 author_tests('xt');
 
 auto_include;
-auto_set_repository;
 
 if (author_context) {
     # gfx++

--- a/README
+++ b/README
@@ -12,6 +12,8 @@ Download it, unpack it, then build it as per the usual:
     % perl Makefile.PL
     % make && make test
 
+Make sure you have `Module::Install` and `Module::Install::AuthorTests` dependencies installed, as well as other prerequisites the build asks for.
+
 Then install it:
 
     % make install


### PR DESCRIPTION
When trying to make the project, I encountered the following problems:

```
perl Makefile.PL 
include /Users/gjtorikian/Development/anyevent-gearman-perl/inc/Module/Install.pm
Bareword "use_test_base" not allowed while "strict subs" in use at Makefile.PL line 18.
Bareword "auto_set_repository" not allowed while "strict subs" in use at Makefile.PL line 24.
Execution of Makefile.PL aborted due to compilation errors.
```
