### PR TITLE
document prefix on worker as public attribute

### DIFF
--- a/lib/AnyEvent/Gearman/Worker.pm
+++ b/lib/AnyEvent/Gearman/Worker.pm
@@ -105,6 +105,12 @@ In latter case, gearman default port 4730 will be used.
 
 You should set at least one job_server.
 
+=item prefix => 'Str',
+
+Sets the namespace / prefix for the function names. This is useful for sharing job servers between different applications or different instances of the same application (different development sandboxes for example).
+
+The namespace is currently implemented as a simple tab separated concatenation of the prefix and the function name.
+
 =back
 
 =head2 register_function( $function_name, $subref )

--- a/lib/AnyEvent/Gearman/Worker/Connection.pm
+++ b/lib/AnyEvent/Gearman/Worker/Connection.pm
@@ -138,7 +138,9 @@ sub process_packet_11 {         # JOB_ASSIGN
 sub work {
     my ($self, $job) = @_;
 
-    my $cb = $self->context->functions->{ $job->function } or return;
+    my $function = $job->function;
+    $function =~ s/^.*?\t// if $self->context->prefix;
+    my $cb = $self->context->functions->{ $function } or return;
     $cb->($job);
 }
 


### PR DESCRIPTION
This is a documented public attribute for the client so I assume it was intended to be public on the worker as well.
