### PR TITLE
use default gearman port by default

### DIFF
--- a/lib/AnyEvent/Gearman/Connection.pm
+++ b/lib/AnyEvent/Gearman/Connection.pm
@@ -68,7 +68,7 @@ sub BUILD {
     my $self = shift;
 
     # parse hostspec
-    my ($host, $service) = parse_hostport $self->hostspec;
+    my ($host, $service) = parse_hostport $self->hostspec, 4730;
     unless (defined $host) {
         $host    = $self->hostspec;
         $service = 4730;

--- a/lib/AnyEvent/Gearman/Connection.pm
+++ b/lib/AnyEvent/Gearman/Connection.pm
@@ -69,10 +69,6 @@ sub BUILD {
 
     # parse hostspec
     my ($host, $service) = parse_hostport $self->hostspec, 4730;
-    unless (defined $host) {
-        $host    = $self->hostspec;
-        $service = 4730;
-    }
 
     unless (defined($host) && defined($service)) {
         die sprintf('Failed to parse hostspec: "%s"', $self->hostspec);


### PR DESCRIPTION
The SYNOPSIS implies that you can specify a hostname/address without a port to use the default port.  This fixes the parse_hostport call so that it does that.
